### PR TITLE
Add zopfli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,18 @@ module.exports = {
 Arguments:
 
 * `asset`: The target asset name. `{file}` is replaced with the original asset. Defaults to `"{file}.gz"`.
-* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is tacken from `zlib`. Defaults to `"gzip"`.
+* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib` (or zopfli for `zopfli`). Defaults to `"gzip"`.
 * `regExp`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.
+
+Option Arguments for Zopfli (see [node-zopfli](https://github.com/pierreinglebert/node-zopfli#options) doc for details):
+* verbose: Default: false,
+* verbose_more: Default: false,
+* numiterations: Default: 15,
+* blocksplitting: Default: true,
+* blocksplittinglast: Default: false,
+* blocksplittingmax: Default: 15
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ function CompressionPlugin(options) {
 			}
 			this.algorithm = function (content, fn) {
 				zopfli.gzip(content, {
-					verbose: true,
-					verbose_more: false,
-					numiterations: 15,
-					blocksplitting: true,
-					blocksplittinglast: false,
-					blocksplittingmax: 15
+					verbose: options.verbose ? options.verbose : false,
+					verbose_more: options.verbose ? options.verbose : false,
+					numiterations: options.verbose ? options.verbose : 15,
+					blocksplitting: options.verbose ? options.verbose : true,
+					blocksplittinglast: options.verbose ? options.verbose : false,
+					blocksplittingmax: options.verbose ? options.verbose : 15
 				}, fn);
 			};
 		} else {

--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ function CompressionPlugin(options) {
 			}
 			this.algorithm = function (content, fn) {
 				zopfli.gzip(content, {
-					verbose: options.verbose ? options.verbose : false,
-					verbose_more: options.verbose ? options.verbose : false,
-					numiterations: options.verbose ? options.verbose : 15,
-					blocksplitting: options.verbose ? options.verbose : true,
-					blocksplittinglast: options.verbose ? options.verbose : false,
-					blocksplittingmax: options.verbose ? options.verbose : 15
+					verbose: options.hasOwnProperty('verbose') ? options.verbose : false,
+					verbose_more: options.hasOwnProperty('verbose_more') ? options.verbose_more : false,
+					numiterations: options.numiterations ? options.numiterations : 15,
+					blocksplitting: options.hasOwnProperty('blocksplitting') ? options.blocksplitting : true,
+					blocksplittinglast: options.hasOwnProperty('blocksplittinglast') ? options.blocksplittinglast : false,
+					blocksplittingmax: options.blocksplittingmax ? options.blocksplittingmax : 15
 				}, fn);
 			};
 		} else {

--- a/index.js
+++ b/index.js
@@ -11,10 +11,28 @@ function CompressionPlugin(options) {
 	this.asset = options.asset || "{file}.gz";
 	this.algorithm = options.algorithm || "gzip";
 	if(typeof this.algorithm === "string") {
-		var zlib = require("zlib");
-		this.algorithm = zlib[this.algorithm];
-		if(!this.algorithm) throw new Error("Algorithm not found in zlib");
-		this.algorithm = this.algorithm.bind(zlib);
+		if (this.algorithm === "zopfli") {
+			try {
+				var zopfli = require("node-zopfli");
+			} catch(err) {
+				throw new Error("node-zopfli not found");
+			}
+			this.algorithm = function (content, fn) {
+				zopfli.gzip(content, {
+					verbose: true,
+					verbose_more: false,
+					numiterations: 15,
+					blocksplitting: true,
+					blocksplittinglast: false,
+					blocksplittingmax: 15
+				}, fn);
+			};
+		} else {
+			var zlib = require("zlib");
+			this.algorithm = zlib[this.algorithm];
+			if(!this.algorithm) throw new Error("Algorithm not found in zlib");
+			this.algorithm = this.algorithm.bind(zlib);
+		}
 	}
 	this.regExp = options.regExp;
 	this.threshold = options.threshold || 0;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "async": "0.2.x"
   },
+  "optionalDependencies": {
+    "node-zopfli": "^1.3.4"
+  },
   "homepage": "http://github.com/webpack/compression-webpack-plugin",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Proposed solution for #2.

`algorithm: "zopfli"` loads zopfli.gzip for compression, if `node-zopfli` dependency is present